### PR TITLE
Kill sshd on SIGTERM instead of waiting for docker stop timeout.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+_term() {
+  echo "Caught SIGTERM signal!"
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap _term SIGTERM
+
 # If there is some public key in keys folder
 # then it copies its contain in authorized_keys file
 if [ "$(ls -A /git-server/keys/)" ]; then
@@ -19,5 +26,7 @@ if [ "$(ls -A /git-server/repos/)" ]; then
   find . -type d -exec chmod g+s '{}' +
 fi
 
-# -D flag avoids executing sshd as a daemon
-/usr/sbin/sshd -D
+/usr/sbin/sshd
+
+child=$!
+wait "$child"

--- a/start.sh
+++ b/start.sh
@@ -26,7 +26,7 @@ if [ "$(ls -A /git-server/repos/)" ]; then
   find . -type d -exec chmod g+s '{}' +
 fi
 
-/usr/sbin/sshd
+/usr/sbin/sshd -D &
 
 child=$!
 wait "$child"


### PR DESCRIPTION
Since `sh` ignores SIGTERM, `docker stop` must wait for the timeout (default ten seconds). By passing SIGTERM through to `sshd`, this wait is avoided.