### PR TITLE
Resets authorized_keys on startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Clear authorized_keys file
+: > /home/git/.ssh/authorized_keys
+
 # If there is some public key in keys folder
 # then it copies its contain in authorized_keys file
 if [ "$(ls -A /git-server/keys/)" ]; then


### PR DESCRIPTION
Without this functionality, even deleting the keys from the host's "keys" directory, they will not be deleted from the Docker container server, which represents both technical limitations and security flaws.