### PR TITLE
Resets authorized_keys on startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
-version: '2'
+version: '3.7'
 
 services:
 
   git-server:
-    image: jkarlos/git-server-docker
-    #build: .
-    restart: always
+    image: anarkrypto/git-server-docker
+    build:
+      context: . # Build Dockerfile from current directory
+    restart: unless-stopped
     container_name: git-server
+    image: anarkrypto/git-server-docker
     ports:
       - "2222:22"
     volumes:

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Clear authorized_keys file
+: > /home/git/.ssh/authorized_keys
+
 # If there is some public key in keys folder
 # then it copies its contain in authorized_keys file
 if [ "$(ls -A /git-server/keys/)" ]; then


### PR DESCRIPTION
Without this functionality, even deleting the keys from the host's "keys" directory, they will not be deleted from the Docker container server, which represents both technical limitations and security flaws.