### PR TITLE
Update alpine version to support ARMv7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.13.2
 
 MAINTAINER Carlos Bernárdez "carlos@z4studios.com"
 


### PR DESCRIPTION
Alpine version 3.4 only provides `linux/amd64` image. I updated a couple of months ago to `alpine:3.13.2` to be able to build `git-server-docker` for ARMv7 It could probably be updated to `3.13.6` which is now the latest (all this new versions have images for 386, amd64 and armv6).
Related to #16 